### PR TITLE
Update website list hostname filter to follow latest rest

### DIFF
--- a/Models/Website.ts
+++ b/Models/Website.ts
@@ -1,4 +1,5 @@
 import LanguageList from './LanguageList';
+import Language from './Language';
 import ContentRootList from './ContentRootList';
 
 export type HostDefinition = {
@@ -15,7 +16,7 @@ export type HostDefinition = {
     /**
      * The default language for the host
      */
-    language: null | string
+    language: null | Language
 }
 
 /**

--- a/Models/WebsiteList.ts
+++ b/Models/WebsiteList.ts
@@ -6,7 +6,7 @@ export const hostnameFilter : (website: Readonly<Website>, host: string, languag
     const matchHost = (website.hosts ? website.hosts.filter(h => {
         if (matchWildcard && h.name === '*') return true;
         if (h.name !== host) return false;
-        return language && h.language ? language === h.language : true;
+        return language && h.language ? language === h.language.name : true;
     }) : []).length > 0;
     return matchHost;
 }


### PR DESCRIPTION
Update language comparison according to latest [Content Delivery REST setup](https://world.optimizely.com/documentation/class-libraries/rest-apis/content-delivery-api/#/SiteDefinitionApi/SiteDefinitionApi_Get_v2). Language is not a string but an object with **name** and **displayName** properties. So comparison needs to be fixed here or else it is always false and websites with several languages are not working anymore since hostnameFilter always blocks it

Here is a live example of the situation
![image](https://user-images.githubusercontent.com/1220105/134002684-f1d3bd67-4fb4-4858-86d8-e4bc68c9bb02.png)
