### PR TITLE
Updated hostfilter language check to fix multi-culture issue

### DIFF
--- a/Models/Website.ts
+++ b/Models/Website.ts
@@ -1,4 +1,5 @@
 import LanguageList from './LanguageList';
+import Language from './Language';
 import ContentRootList from './ContentRootList';
 
 export type HostDefinition = {
@@ -15,7 +16,7 @@ export type HostDefinition = {
     /**
      * The default language for the host
      */
-    language: null | string
+    language: null | Language
 }
 
 /**

--- a/Models/WebsiteList.ts
+++ b/Models/WebsiteList.ts
@@ -6,7 +6,7 @@ export const hostnameFilter : (website: Readonly<Website>, host: string, languag
     const matchHost = (website.hosts ? website.hosts.filter(h => {
         if (matchWildcard && h.name === '*') return true;
         if (h.name !== host) return false;
-        return language && h.language ? language === h.language : true;
+        return language && h.language ? language === h.language.name : true;
     }) : []).length > 0;
     return matchHost;
 }

--- a/dist/Models/WebsiteList.js
+++ b/dist/Models/WebsiteList.js
@@ -4,7 +4,7 @@ export const hostnameFilter = (website, host, language, matchWildcard = true) =>
             return true;
         if (h.name !== host)
             return false;
-        return language && h.language ? language === h.language : true;
+        return language && h.language ? language === h.language.name : true;
     }) : []).length > 0;
     return matchHost;
 };


### PR DESCRIPTION
Hosts language object is not a sting according to the [REST structure](https://world.optimizely.com/documentation/class-libraries/rest-apis/content-delivery-api/#/SiteDefinitionApi/SiteDefinitionApi_Get_v2) so if website has multiple languages the hostfilter always return false and causing issues since string language code is compared to an object.

So I updated the Hosts object and hostfilter to follow official REST structure. Hopefully it will help 