### PR TITLE
Episerver spa route hash support

### DIFF
--- a/Routing/EpiSpaRouter.tsx
+++ b/Routing/EpiSpaRouter.tsx
@@ -62,7 +62,7 @@ const ElementNavigation : React.FunctionComponent = (props) : React.ReactElement
 
                 // Only act if we remain on the same domain
                 if (targetUrl.origin === currentUrl.origin) {
-                    newPath = targetUrl.pathname;
+                    newPath = targetUrl.pathname + targetUrl.hash;
                 }
             }
 

--- a/dist/Routing/EpiSpaRouter.js
+++ b/dist/Routing/EpiSpaRouter.js
@@ -53,7 +53,7 @@ const ElementNavigation = (props) => {
                 const targetUrl = new URL(link.href, currentUrl);
                 // Only act if we remain on the same domain
                 if (targetUrl.origin === currentUrl.origin) {
-                    newPath = targetUrl.pathname;
+                    newPath = targetUrl.pathname + targetUrl.hash;
                 }
             }
             // Do not navigate to the same page


### PR DESCRIPTION
Internal links didn't support hashes and anchor links because of that didn't work. Added moving hash for target links. This needed for example if links with anchors are used inside xHtml properties in any blocks. 